### PR TITLE
Changed Prefab Save Method

### DIFF
--- a/Assets/UniTiled/Scripts/TileCreator.cs
+++ b/Assets/UniTiled/Scripts/TileCreator.cs
@@ -100,7 +100,6 @@ public class TileCreator : MonoBehaviour
 
         captureCamTrans = captureCamObj.transform;
         captureCamTrans.eulerAngles = new Vector3(90.0f, 0, 0);
-        
 
         captureCam = captureCamObj.AddComponent<Camera>();
         captureCam.clearFlags = CameraClearFlags.Color;
@@ -117,7 +116,6 @@ public class TileCreator : MonoBehaviour
             UnityEditor.EditorApplication.isPlaying = false;
             return;
         }
-        
 
         prevCam = prevCamObj.GetComponent<Camera>();
         if(prevCam == null)
@@ -200,7 +198,7 @@ public class TileCreator : MonoBehaviour
                 }
                 //Object prefab = PrefabUtility.CreateEmptyPrefab("Assets/Resources/" + ATLASES_FOLDER + "/" + collectionName + ".prefab");
                 //PrefabUtility.ReplacePrefab(gameObject, prefab, ReplacePrefabOptions.ConnectToPrefab);
-                PrefabUtility.SaveAsPrefabAssetAndConnect(gameObject, "Assets/Resources/" + ATLASES_FOLDER + "/" + collectionName, InteractionMode.AutomatedAction);
+                PrefabUtility.SaveAsPrefabAssetAndConnect(gameObject, "Assets/Resources/" + ATLASES_FOLDER + "/" + collectionName + ".prefab", InteractionMode.AutomatedAction);
 
                 Debug.Log("Your tile collection was saved as " + atlasesFullPath + "/" + collectionName + ".prefab");
             }

--- a/Assets/UniTiled/Scripts/TileCreator.cs
+++ b/Assets/UniTiled/Scripts/TileCreator.cs
@@ -198,9 +198,9 @@ public class TileCreator : MonoBehaviour
                 {
                     Directory.CreateDirectory(atlasesFullPath);
                 }
-                Object prefab = PrefabUtility.CreateEmptyPrefab("Assets/Resources/" + ATLASES_FOLDER + "/" + collectionName + ".prefab");
-
-                PrefabUtility.ReplacePrefab(gameObject, prefab, ReplacePrefabOptions.ConnectToPrefab);
+                //Object prefab = PrefabUtility.CreateEmptyPrefab("Assets/Resources/" + ATLASES_FOLDER + "/" + collectionName + ".prefab");
+                //PrefabUtility.ReplacePrefab(gameObject, prefab, ReplacePrefabOptions.ConnectToPrefab);
+                PrefabUtility.SaveAsPrefabAssetAndConnect(gameObject, "Assets/Resources/" + ATLASES_FOLDER + "/" + collectionName, InteractionMode.AutomatedAction);
 
                 Debug.Log("Your tile collection was saved as " + atlasesFullPath + "/" + collectionName + ".prefab");
             }


### PR DESCRIPTION
Changed old method used in Unity 2018 :
- Create empty prefab
- Replace with existing object to turn into Prefab

Used new method available:
- Save instance of existing GameObject as Prefab @ location